### PR TITLE
Making retries and interval configurable via the Connector

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -31,8 +31,10 @@ func main() {
 		SessionSecrets: iscsi.Secrets{
 			UserName: "",
 			Password: ""},
-		Lun:       int32(*lun),
-		Multipath: *multipath,
+		Lun:           int32(*lun),
+		Multipath:     *multipath,
+		Timeout:       10,
+		CheckInterval: 1,
 	}
 	path, err := iscsi.Connect(c)
 	log.Printf("path is: %s\n", path)


### PR DESCRIPTION
Often hosts with a lot of existing iscsi connections will bog down during new login operations and require waiting for longer periods to obtain a successful login.  We should allow configuring login timeouts to support these cases.