### PR TITLE
Don't try and access an element of an empty slice

### DIFF
--- a/iscsi/iscsi.go
+++ b/iscsi/iscsi.go
@@ -304,6 +304,9 @@ func Connect(c Connector) (string, error) {
 			devicePaths = append(devicePaths, devicePath)
 			continue
 		}
+		if len(devicePaths) < 1 {
+			return "", fmt.Errorf("failed to find device path: %s", devicePath)
+		}
 		log.Trace.Printf("Device Paths: %s", devicePaths)
 		devicePath = devicePaths[0]
 		for _, path := range devicePaths {

--- a/iscsi/iscsi_test.go
+++ b/iscsi/iscsi_test.go
@@ -89,7 +89,10 @@ func fakeExecCommand(command string, args ...string) *exec.Cmd {
 	cs := []string{"-test.run=TestExecCommandHelper", "--", command}
 	cs = append(cs, args...)
 	cmd := exec.Command(os.Args[0], cs...)
-	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1"}
+	es := strconv.Itoa(mockedExitStatus)
+	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1",
+		"STDOUT=" + mockedStdout,
+		"EXIT_STATUS=" + es}
 	return cmd
 }
 
@@ -187,6 +190,7 @@ func Test_extractTransportName(t *testing.T) {
 func Test_sessionExists(t *testing.T) {
 	mockedExitStatus = 0
 	mockedStdout = "tcp: [4] 192.168.1.107:3260,1 iqn.2010-10.org.openstack:volume-eb393993-73d0-4e39-9ef4-b5841e244ced (non-flash)\n"
+	execCommand = fakeExecCommand
 	type args struct {
 		tgtPortal string
 		tgtIQN    string


### PR DESCRIPTION
On Connect we were blindly accessing devicePaths[0] without checking to
see if the scan actually found something or not.  This patch just
addresses that issue by checking the length of devicePaths before trying
to access it.

While we're at it, we also finish up the 1/2 done getSessions unit test.